### PR TITLE
Add controller and DTO tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Application
+APP_NAME=NestJS Starter
+APP_HOST=localhost
+APP_PORT=3000
+NODE_ENV=local
+
+# Authentication
+JWT_SECRET=your-jwt-secret
+JWT_EXPIRES_IN=3600s
+JWT_REFRESH_SECRET=your-refresh-secret
+JWT_REFRESH_EXPIRES_IN=30d
+
+# Database
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_DATABASE=postgres
+DB_DEBUG=false
+DB_ENABLE_QUERY_LOG=false

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A robust and scalable NestJS boilerplate designed to kickstart your backend deve
     * **Migrations:** Setup for database schema migrations.
     * **Seeding:** Placeholder and structure for database seeding.
 * **Authentication & Authorization:** Basic setup for JWT-based authentication (can be extended).
-* **Logging:** Centralized logging module.
+* **Logging:** Centralized logging module. You can easily extend `LoggerService` to pipe logs to Winston, CloudWatch, or any external system.
 * **Validation:** Request validation using `class-validator` and `class-transformer`.
 * **Error Handling:** Global exception filter for consistent error responses.
 * **Modularity:** Well-defined project structure promoting separation of concerns.
@@ -57,7 +57,7 @@ The project structure is designed to be modular, scalable, and maintainable.
 │   │   │
 │   │   ├── logger/                 # ระบบ Logging ส่วนกลาง
 │   │   │   ├── logger.module.ts    #   - โมดูลสำหรับให้บริการ LoggerService
-│   │   │   ├── logger.service.ts   #   - เซอร์วิสสำหรับการ Log (อาจจะ wrap Winston หรือ NestJS Logger)
+│   │   │   ├── logger.service.ts   #   - เซอร์วิสสำหรับการ Log (เริ่มต้นใช้ console แต่สามารถต่อยอดให้เชื่อมกับ Winston หรือบริการภายนอกได้)
 │   │   │   ├── logger.interface.ts #   - (Optional) Interface สำหรับ Logger (ถ้ามีการ implement เอง)
 │   │   │   └── index.ts            #   - (Optional) Export ทุกอย่างจาก logger/
 │   │   │
@@ -82,7 +82,7 @@ The project structure is designed to be modular, scalable, and maintainable.
 │   │   │   └── .gitkeep            #     (Boilerplate อาจจะว่าง หรือมีตัวอย่าง migration แรก)
 │   │   └── seeds/                  #   - โฟลเดอร์สำหรับ Database Seeds (ไฟล์ .ts หรือตาม library ที่ใช้)
 │   │       └── .gitkeep            #     (ถ้าใช้ SeedModule อาจจะเก็บแค่ raw data หรือไม่ใช้เลย)
-│   │                               #   *Entities: โดยทั่วไปจะอยู่ในแต่ละ Feature Module (e.g., src/modules/users/entities/user.entity.ts)
+│   │                               #   *Entities: โดยทั่วไปจะอยู่ในแต่ละ Feature Module (e.g., src/modules/user/entities/user.entity.ts)
 │   │                               #    และ data-source.ts จะถูกตั้งค่าให้ค้นหา entities จาก path เหล่านั้น (e.g., 'src/modules/**/*.entity.ts')
 │   │
 │   ├── config/                     # Project-Specific Typed Configurations: โครงสร้าง Config ที่ซับซ้อนของโปรเจกต์นี้
@@ -121,10 +121,12 @@ The project structure is designed to be modular, scalable, and maintainable.
 │       │   ├── constants/          #     - Auth-specific constants
 │       │   └── entities/           #     - (Optional, e.g., RefreshTokenEntity, ถ้า UserEntity อยู่อีก Module)
 │       │
-│       ├── users/                  #   - (ตัวอย่าง) โมดูลจัดการผู้ใช้งาน
-│       │   ├── users.module.ts
-│       │   ├── users.controller.ts
-│       │   ├── users.service.ts
+│       ├── user/                   #   - (ตัวอย่าง) โมดูลจัดการผู้ใช้งาน
+│       │   ├── user.module.ts
+│       │   ├── controllers/
+│       │   │   └── user.controller.ts
+│       │   ├── services/
+│       │   │   └── user.service.ts
 │       │   ├── dto/
 │       │   ├── entities/           #     - User.entity.ts
 │       │   ├── repositories/       #     - (Optional) User.repository.ts
@@ -194,6 +196,7 @@ The project structure is designed to be modular, scalable, and maintainable.
     cp .env.example .env
     ```
 2.  Open the `.env` file and update the environment variables according to your setup (database credentials, JWT secrets, API keys, etc.). The required and optional variables are typically defined and validated via `src/core/config/validation.ts` and specific `src/config/*.config.ts` files.
+3.  Environment files are loaded in the following priority: `.env.local`, `.env.$NODE_ENV.local`, `.env.$NODE_ENV`, then `.env`. This allows you to override settings per environment while keeping sane defaults in `.env.example`.
 
 ## 🚀 Running the Application
 
@@ -230,6 +233,7 @@ The project structure is designed to be modular, scalable, and maintainable.
     ```bash
     npm run test:e2e
     ```
+    The `test/` directory includes example E2E tests such as `user.e2e-spec.ts`. Feel free to expand these with more validation and error cases.
 
 * **Run test coverage:**
     ```bash
@@ -244,6 +248,7 @@ This boilerplate uses TypeORM for database interactions.
 
 * The main TypeORM CLI configuration is in `src/database/data-source.ts`. This file is used by TypeORM CLI commands for migrations and other operations. It should be configured to find your entities (typically located within feature modules like `src/modules/**/*.entity.ts`) and migration files.
 * The NestJS database connection module is in `src/core/database/database.module.ts`, which uses the configuration provided via the `CoreConfigService` and/or project-specific typed database configurations from `src/config/database.config.ts`.
+* For advanced setups (multiple connections or read replicas), consider extending `DatabaseModule` with additional configuration files and providers.
 
 ### Migrations
 
@@ -289,6 +294,7 @@ Database seeding can be handled in a few ways:
 * **Environment Variables:** Loaded from `.env` files by `src/core/config/config.module.ts`.
 * **Core Validation:** Basic ENV variables required by the boilerplate can be validated using a Joi schema in `src/core/config/validation.ts`.
 * **Typed Configurations:** Project-specific, structured configurations are defined in `src/config/*.config.ts` using `@nestjs/config`'s `registerAs` pattern. These are validated using `class-validator` via the utility in `src/core/config/utils/validate-config.util.ts`.
+* **Environment Overrides:** You can create environment-specific files such as `.env.development` or `.env.production` to override values. The loading priority is the same as mentioned above.
 * **Accessing Config:** Use the `CoreConfigService` (from `src/core/config/config.service.ts`) or inject typed configurations directly using `@Inject(config.KEY)`.
 
 ## 📄 API Documentation (Swagger)

--- a/src/modules/auth/dtos/requests/login-request.dto.spec.ts
+++ b/src/modules/auth/dtos/requests/login-request.dto.spec.ts
@@ -1,0 +1,20 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { LoginRequestDto } from './login-request.dto';
+
+describe('LoginRequestDto', () => {
+  it('validates a correct payload', async () => {
+    const dto = plainToInstance(LoginRequestDto, {
+      username: 'user@example.com',
+      password: 'pass',
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('fails with empty fields', async () => {
+    const dto = plainToInstance(LoginRequestDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/modules/auth/dtos/requests/refresh-token-request.dto.spec.ts
+++ b/src/modules/auth/dtos/requests/refresh-token-request.dto.spec.ts
@@ -1,0 +1,19 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { RefreshTokenRequestDto } from './refresh-token-request.dto';
+
+describe('RefreshTokenRequestDto', () => {
+  it('validates a correct payload', async () => {
+    const dto = plainToInstance(RefreshTokenRequestDto, {
+      refreshToken: 'token',
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('fails when refreshToken missing', async () => {
+    const dto = plainToInstance(RefreshTokenRequestDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/modules/auth/services/auth.service.spec.ts
+++ b/src/modules/auth/services/auth.service.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
-import { UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserService } from '#modules/user/services/user.service';
 import { RefreshTokenRepository } from '../repositories/refresh-token.repository';
@@ -39,14 +38,21 @@ describe('AuthService', () => {
   });
 
   it('should login successfully', async () => {
-    mockUserService.findByUsername.mockResolvedValue({ id: '1', password: 'hash' });
+    mockUserService.findByUsername.mockResolvedValue({
+      id: '1',
+      password: 'hash',
+    });
     (bcrypt.compare as jest.Mock).mockResolvedValue(true);
     (uuidv4 as jest.Mock).mockReturnValue('refresh');
     mockJwtService.sign.mockReturnValue('token');
 
     const result = await service.login({ username: 'user', password: 'pass' });
 
-    expect(result).toEqual({ accessToken: 'token', refreshToken: 'refresh', userId: '1' });
+    expect(result).toEqual({
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      userId: '1',
+    });
     expect(mockTokenRepo.createToken).toHaveBeenCalledWith('1', 'refresh');
   });
 
@@ -59,22 +65,32 @@ describe('AuthService', () => {
   });
 
   it('should refresh token', async () => {
-    mockTokenRepo.findByToken.mockResolvedValue({ userId: '1', revokedAt: null });
+    mockTokenRepo.findByToken.mockResolvedValue({
+      userId: '1',
+      revokedAt: null,
+    });
     mockUserService.findById.mockResolvedValue({ id: '1' });
     mockJwtService.sign.mockReturnValue('new');
 
     const result = await service.refresh('refresh');
-    expect(result).toEqual({ accessToken: 'new' });
+    expect(result).toEqual({
+      accessToken: 'new',
+      refreshToken: 'refresh',
+      userId: '1',
+    });
   });
 
   it('should throw when refresh token invalid', async () => {
     mockTokenRepo.findByToken.mockResolvedValue(null);
 
-    await expect(service.refresh('bad')).rejects.toBeInstanceOf(UnauthorizedException);
+    await expect(service.refresh('bad')).rejects.toBeInstanceOf(AppException);
   });
 
   it('should revoke token', async () => {
-    mockTokenRepo.findByToken.mockResolvedValue({ userId: '1', revokedAt: null });
+    mockTokenRepo.findByToken.mockResolvedValue({
+      userId: '1',
+      revokedAt: null,
+    });
 
     const result = await service.revoke('1', 'refresh');
     expect(result).toEqual({ success: true });
@@ -84,6 +100,8 @@ describe('AuthService', () => {
   it('should throw when revoke token invalid', async () => {
     mockTokenRepo.findByToken.mockResolvedValue(null);
 
-    await expect(service.revoke('1', 'bad')).rejects.toBeInstanceOf(UnauthorizedException);
+    await expect(service.revoke('1', 'bad')).rejects.toBeInstanceOf(
+      AppException,
+    );
   });
 });

--- a/src/modules/auth/services/auth.service.ts
+++ b/src/modules/auth/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { UserService } from '#modules/user/services/user.service';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';

--- a/src/modules/user/dtos/requests/user-query.dto.spec.ts
+++ b/src/modules/user/dtos/requests/user-query.dto.spec.ts
@@ -1,0 +1,19 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UserQueryDto } from './user-query.dto';
+import { DEFAULT_PAGINATION } from '#shared/constants/pagination.constant';
+
+describe('UserQueryDto', () => {
+  it('transforms values correctly', async () => {
+    const dto = plainToInstance(UserQueryDto, {
+      page: '-1',
+      perPage: '200',
+      isActive: 'true',
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+    expect(dto.page).toBe(DEFAULT_PAGINATION.PAGE);
+    expect(dto.perPage).toBe(DEFAULT_PAGINATION.MAX_LIMIT);
+    expect(dto.isActive).toBe(true);
+  });
+});

--- a/src/modules/user/services/user.service.spec.ts
+++ b/src/modules/user/services/user.service.spec.ts
@@ -5,6 +5,7 @@ import { UserRepository } from '../repositories/user.repository';
 const mockRepo = {
   findByEmail: jest.fn(),
   findById: jest.fn(),
+  findByMobile: jest.fn(),
   findAll: jest.fn(),
 };
 
@@ -29,12 +30,12 @@ describe('UserService', () => {
     expect(result).toEqual({ id: '1', email: 'a@b.com' });
   });
 
-  it('should find by id when username has no @', async () => {
-    mockRepo.findById.mockResolvedValue({ id: '1' });
+  it('should find by mobile when username has no @', async () => {
+    mockRepo.findByMobile.mockResolvedValue({ id: '1' });
 
     const result = await service.findByUsername('1');
 
-    expect(mockRepo.findById).toHaveBeenCalledWith('1');
+    expect(mockRepo.findByMobile).toHaveBeenCalledWith('1');
     expect(result).toEqual({ id: '1' });
   });
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,12 +2,17 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
 
 describe.skip('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
+    process.env.APP_NAME = 'test';
+    process.env.DB_USERNAME = 'a';
+    process.env.DB_PASSWORD = 'b';
+    process.env.JWT_SECRET = 'secret';
+    process.env.JWT_REFRESH_SECRET = 'secret';
+    const { AppModule } = await import('./../src/app.module');
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -14,8 +14,12 @@ describe('AuthController (e2e)', () => {
       refreshToken: 'refresh',
       userId: '1',
     }),
-    refresh: jest.fn(),
-    revoke: jest.fn(),
+    refresh: jest.fn().mockResolvedValue({
+      accessToken: 'new',
+      refreshToken: 'refresh',
+      userId: '1',
+    }),
+    revoke: jest.fn().mockResolvedValue(undefined),
   };
 
   beforeAll(async () => {
@@ -25,14 +29,16 @@ describe('AuthController (e2e)', () => {
     })
       .overrideGuard(JwtAuthGuard)
       .useValue({
-        canActivate: (context) => {
-          const req = context.switchToHttp().getRequest();
+        canActivate: (context: import('@nestjs/common').ExecutionContext) => {
+          const req = context
+            .switchToHttp()
+            .getRequest<{ user?: Partial<UserEntity> }>();
           req.user = {
             id: '1',
             email: 'a@b.com',
             fullName: 'A',
             isActive: true,
-          } as Partial<UserEntity>;
+          };
           return true;
         },
       })
@@ -65,14 +71,27 @@ describe('AuthController (e2e)', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     };
+    return request(app.getHttpServer()).get('/auth/me').expect(200).expect({
+      id: user.id,
+      email: user.email,
+      fullName: user.fullName,
+      isActive: user.isActive,
+    });
+  });
+
+  it('/auth/refresh (POST)', () => {
     return request(app.getHttpServer())
-      .get('/auth/me')
-      .expect(200)
-      .expect({
-        id: user.id,
-        email: user.email,
-        fullName: user.fullName,
-        isActive: user.isActive,
-      });
+      .post('/auth/refresh')
+      .send({ refreshToken: 'refresh' })
+      .expect(201)
+      .expect({ accessToken: 'new', refreshToken: 'refresh', userId: '1' });
+  });
+
+  it('/auth/revoke (POST)', () => {
+    return request(app.getHttpServer())
+      .post('/auth/revoke')
+      .send({ refreshToken: 'refresh' })
+      .expect(201)
+      .expect('');
   });
 });


### PR DESCRIPTION
## Summary
- test more endpoints for the auth controller
- add unit tests for DTO validation
- fix failing unit tests
- adjust skipped e2e spec to set env vars

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68417cf01414832ba0092ed0484ae8e4